### PR TITLE
La sintaxis de watch es obsoleta

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,6 +40,6 @@ gulp.task('style_min', function(){
 //gulp watch
 
 gulp.task('watch', ['style_min'], function (){
-  gulp.watch('scss/**/*.scss', ['style_min']);
-
+  gulp.watch('scss/**/*.scss', gulp.series('style_min'));
+  
 });


### PR DESCRIPTION
En la versión actual de gulp se usa de esta manera